### PR TITLE
Bug Fix for "ofPixels mirrorTo horizontal"

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -1176,7 +1176,7 @@ void ofPixels_<PixelType>::mirrorTo(ofPixels_<PixelType> & dst, bool vertically,
 		int hToDo = height;
 		for (int i = 0; i < wToDo; i++){
 			for (int j = 0; j < hToDo; j++){
-				int pixelb = i;
+				int pixelb = j*width + (width - 1 - i);
 				int pixela = j*width + i;
 				for (int k = 0; k < bytesPerPixel; k++){
 					dst[pixela*bytesPerPixel + k] = pixels[pixelb*bytesPerPixel + k];


### PR DESCRIPTION
When mirrorTo-ing ofPixels horizontally, line 1179, which was
int pixelb = i;
previously, should be 
int pixelb = j*width + (width - 1 - i);.

Otherwise, results in very irregular behaviours as below: (grayscale images that look like strips on the left are mirrored versions of top-left-most image using previous ofPixels mirrorTo horizontally)
![default](https://cloud.githubusercontent.com/assets/6938192/16040341/eca74fb6-3269-11e6-9ec8-d98dbcfb95f0.PNG)
